### PR TITLE
Fix relayer 

### DIFF
--- a/build/start_tor.sh
+++ b/build/start_tor.sh
@@ -21,7 +21,7 @@ echo "#################################################"
 
 sed -i 's/example.com/'"$address"'/g' /etc/nginx/nginx.conf
 
-PASSWORD=$(echo $(LC_CTYPE=C tr -dc 'A-HJ-NPR-Za-km-z2-9' < /dev/urandom | head -c 20)) && \
+PASSWORD=$(openssl rand -base64 14) && \
     openssl genrsa -des3 -passout pass:${PASSWORD} -out /etc/nginx/certs/server.pass.key 2048 && \
     openssl rsa -passin pass:${PASSWORD} -in /etc/nginx/certs/server.pass.key -out /etc/nginx/certs/server.key && \
     rm /etc/nginx/certs/server.pass.key && \

--- a/build/start_tor.sh
+++ b/build/start_tor.sh
@@ -1,4 +1,4 @@
-#!/bin/sh 
+#!/bin/sh
 
 HIDDEN_SERVICE_DIR=/hidden_service
 
@@ -19,7 +19,7 @@ echo "https://${address}"
 echo
 echo "#################################################"
 
-sed -i 's/example.com/'"$address"'/g' /etc/nginx/nginx.conf 
+sed -i 's/example.com/'"$address"'/g' /etc/nginx/nginx.conf
 
 PASSWORD=$(echo $(LC_CTYPE=C tr -dc 'A-HJ-NPR-Za-km-z2-9' < /dev/urandom | head -c 20)) && \
     openssl genrsa -des3 -passout pass:${PASSWORD} -out /etc/nginx/certs/server.pass.key 2048 && \


### PR DESCRIPTION
I was having trouble using the relayer, the only obvious error I could find in the logs was a `broken pipe`. I fixed this error by using openssl to generate the password to avoid using pipes at all.

Error:
```
2020-03-14 02:11:28,042 CRIT Supervisor is running as root.  Privileges were not dropped because no user is specified in the config file.  If you intend to run as root, you can set user=root in the config file to avoid this message.
2020-03-14 02:11:28,046 INFO supervisord started with pid 1
2020-03-14 02:11:29,049 INFO spawned: 'ngix_00' with pid 7
2020-03-14 02:11:29,050 INFO spawned: 'redis_00' with pid 8
2020-03-14 02:11:29,052 INFO spawned: 'relayer' with pid 9
2020-03-14 02:11:29,053 INFO spawned: 'tor' with pid 10
2020-03-14 02:11:29,056 INFO success: ngix_00 entered RUNNING state, process has stayed up for > than 0 seconds (startsecs)
#################################################
Hidden service address:

http://[...].onion
or
https://[...].onion

#################################################
tr: write error: Broken pipe
Generating RSA private key, 2048 bit long modulus (2 primes)
.+++++
.......................................+++++
e is 65537 (0x010001)
writing RSA key
Mar 14 02:11:29.152 [notice] Tor 0.4.1.7 running on Linux with Libevent 2.1.11-stable, OpenSSL 1.1.1d, Zlib 1.2.11, Liblzma N/A, and Libzstd N/A.
Mar 14 02:11:29.152 [notice] Tor can't help you if you use it wrong! Learn how to be safe at https://www.torproject.org/download/download#warning
Mar 14 02:11:29.153 [notice] Read configuration file "/etc/tor/torrc".
Mar 14 02:11:29.158 [notice] Opening Socks listener on 127.0.0.1:9050
Mar 14 02:11:29.158 [notice] Opened Socks listener on 127.0.0.1:9050
Gas price oracle started.
Relayer started on port 8000
2020-03-14 02:11:30,062 INFO success: redis_00 entered RUNNING state, process has stayed up for > than 1 seconds (startsecs)
2020-03-14 02:11:30,062 INFO success: relayer entered RUNNING state, process has stayed up for > than 1 seconds (startsecs)
2020-03-14 02:11:30,062 INFO success: tor entered RUNNING state, process has stayed up for > than 1 seconds (startsecs)
```

and after the update:
```
2020-03-14 18:59:05,701 CRIT Supervisor is running as root.  Privileges were not dropped because no user is specified in the config file.  If you intend to run as root, you can set user=root in the config file to avoid this message.
2020-03-14 18:59:05,704 INFO supervisord started with pid 1
2020-03-14 18:59:06,707 INFO spawned: 'ngix_00' with pid 7
2020-03-14 18:59:06,709 INFO spawned: 'redis_00' with pid 8
2020-03-14 18:59:06,710 INFO spawned: 'relayer' with pid 9
2020-03-14 18:59:06,711 INFO spawned: 'tor' with pid 10
2020-03-14 18:59:06,714 INFO success: ngix_00 entered RUNNING state, process has stayed up for > than 0 seconds (startsecs)
Gas price oracle started.
#################################################
Hidden service address:

http://[...].onion
or
https://[...].onion

#################################################
Generating RSA private key, 2048 bit long modulus (2 primes)
2020-03-14 18:59:07,708 INFO success: redis_00 entered RUNNING state, process has stayed up for > than 1 seconds (startsecs)
2020-03-14 18:59:07,710 INFO success: relayer entered RUNNING state, process has stayed up for > than 1 seconds (startsecs)
2020-03-14 18:59:07,711 INFO success: tor entered RUNNING state, process has stayed up for > than 1 seconds (startsecs)
Relayer started on port 8000
```

NOTE: here is the dnp hash of my the package I tested with: `/ipfs/QmT4LDtJh6RNhPFdpQp5Eibdjev3esnQMZ7Dp2sVf2HyPX`